### PR TITLE
Add agent loop helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ for tool_call in resps[0].tool_calls:
     # this is dumb sorry will make it better
     tool_to_call = [x for x in tools if x.name == tool_call.name][0]
     tool_to_call.call(**tool_call.arguments) # in async code, use .acall()
+
+# or use the built-in agent loop to handle this automatically
+import asyncio
+
+async def main():
+    conv = Conversation.user("List the files in the current directory")
+    conv, resp = await client.run_agent_loop(conv, tools=tools)
+    print(resp.content.completion)
+
+asyncio.run(main())
 ```
 
 ### Prompt Caching (Anthropic)

--- a/examples/agent_loop.md
+++ b/examples/agent_loop.md
@@ -1,0 +1,24 @@
+# Automated Agent Loops
+
+`LLMClient` provides a helper `run_agent_loop` method that automates the common pattern of alternating between model calls and tool executions. You seed it with an initial `Conversation` (or plain string) and a list of tools. The method keeps sending the conversation to the model, executes any tool calls it returns, appends the results, and repeats until the model stops calling tools or a maximum round count is reached.
+
+```python
+import asyncio
+from lm_deluge import LLMClient, Tool, Conversation
+
+# simple tool
+def add(a: int, b: int) -> int:
+    return a + b
+
+add_tool = Tool.from_function(add)
+
+async def main():
+    client = LLMClient.basic("gpt-4.1-mini")
+    conv = Conversation.user("What is 2+2? Use the add tool if needed.")
+    conv, resp = await client.run_agent_loop(conv, tools=[add_tool])
+    print(resp.content.completion)
+
+asyncio.run(main())
+```
+
+The returned `Conversation` contains the full history including tool results, and `resp` is the final `APIResponse` from the model.


### PR DESCRIPTION
## Summary
- implement `run_agent_loop` and `run_agent_loop_sync` on `LLMClient`
- document feature in README
- add new example file demonstrating usage

## Testing
- `python -m py_compile src/lm_deluge/client.py`

------
https://chatgpt.com/codex/tasks/task_e_6858ede189c4832289627ff67635edc3