### PR TITLE
Fix final status tracking

### DIFF
--- a/src/lm_deluge/client.py
+++ b/src/lm_deluge/client.py
@@ -421,7 +421,8 @@ class LLMClient(BaseModel):
 
             # Sleep - original logic
             await asyncio.sleep(seconds_to_sleep_each_loop + tracker.seconds_to_pause)
-            tracker.log_final_status()
+
+        tracker.log_final_status()
 
         if return_completions_only:
             return [r.completion if r is not None else None for r in results]


### PR DESCRIPTION
## Summary
- ensure `log_final_status` only runs after the main loop

## Testing
- `pytest -q` *(fails: unable to download tiktoken files due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68743e62e38c8322b650d84ad690cfc5