### PR TITLE
Avoid unnecessary prompt fingerprinting

### DIFF
--- a/src/lm_deluge/request_context.py
+++ b/src/lm_deluge/request_context.py
@@ -43,7 +43,12 @@ class RequestContext:
 
     def __post_init__(self):
         # Compute cache key from prompt fingerprint
-        self.cache_key = self.prompt.fingerprint
+        # Only do this when caching is enabled so we avoid
+        # generating fingerprints for images unnecessarily.
+        if self.cache is not None:
+            self.cache_key = self.prompt.fingerprint
+        else:
+            self.cache_key = ""
 
         # Compute token count
         self.num_tokens = self.prompt.count_tokens(self.sampling_params.max_new_tokens)


### PR DESCRIPTION
## Summary
- only generate a prompt fingerprint in `RequestContext.__post_init__` when a cache is specified

## Testing
- `ruff check src/lm_deluge/request_context.py`
- `pyright src/lm_deluge/request_context.py`
- `python tests/core/test_tool_validation.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6883b1b6aa5083229a250a7c1b3eae68