### PR TITLE
Handle no reasoning effort for Gemini requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ We support all models in `src/lm_deluge/models.py`. Vertex support is not planne
 
 ## Feature Support
 
-We support structured outputs via `json_mode` parameter provided to `SamplingParams`. Structured outputs with a schema are planned. Reasoning models are supported via the `reasoning_effort` parameter, which is translated to a thinking budget for Claude/Gemini. Image models are supported. We support tool use as documented above. We support logprobs for OpenAI models that return them.
+We support structured outputs via `json_mode` parameter provided to `SamplingParams`. Structured outputs with a schema are planned. Reasoning models are supported via the `reasoning_effort` parameter, which is translated to a thinking budget for Claude/Gemini. Passing `None` (or the string `"none"`) disables Gemini thoughts entirely. Image models are supported. We support tool use as documented above. We support logprobs for OpenAI models that return them.
 
 ## Built‑in tools
 

--- a/tests/core/test_gemini_thinking_config.py
+++ b/tests/core/test_gemini_thinking_config.py
@@ -1,0 +1,25 @@
+import asyncio
+
+from lm_deluge.api_requests.gemini import _build_gemini_request
+from lm_deluge.config import SamplingParams
+from lm_deluge.models import APIModel
+from lm_deluge.prompt import Conversation
+
+
+def test_gemini_no_reasoning_effort():
+    """Gemini request should disable thoughts when reasoning_effort is None."""
+    model = APIModel.from_registry("gemini-2.5-pro-gemini")
+    convo = Conversation.user("Hello")
+    request = asyncio.run(
+        _build_gemini_request(
+            model,
+            convo,
+            None,
+            SamplingParams(reasoning_effort=None),
+        )
+    )
+    thinking = request["generationConfig"].get("thinkingConfig")
+    assert thinking is not None
+    assert thinking.get("includeThoughts") is False
+    assert thinking.get("thinkingBudget") == 0
+


### PR DESCRIPTION
## Summary
- disable Gemini reasoning features when `reasoning_effort` is `None` or `'none'`
- document that `None`/`"none"` disables thoughts
- test Gemini request generation with no reasoning effort

## Testing
- `pre-commit run --files src/lm_deluge/api_requests/gemini.py README.md tests/core/test_gemini_thinking_config.py` *(fails: pre-commit not installed)*
- `python tests/core/test_gemini_thinking_config.py` *(fails: unable to download tiktoken model files)*

------
https://chatgpt.com/codex/tasks/task_e_68853c4ce7f0832286c9e5d46e7d1547