### PR TITLE
Add configurable progress tracking with queueing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ print(resp[0].completion)
 API calls can be customized in a few ways.
 
 1. **Sampling Parameters.** This determines things like structured outputs, maximum completion tokens, nucleus sampling, etc. Provide a custom `SamplingParams` to the `LLMClient` to set temperature, top_p, json_mode, max_new_tokens, and/or reasoning_effort. You can pass 1 `SamplingParams` to use for all models, or a list of `SamplingParams` that's the same length as the list of models. You can also pass many of these arguments directly to `LLMClient.basic` so you don't have to construct an entire `SamplingParams` object.
-2. **Arguments to LLMClient.** This is where you set request timeout, rate limits, model name(s), model weight(s) for distributing requests across models, retries, and caching.
+2. **Arguments to LLMClient.** This is where you set request timeout, rate limits, model name(s), model weight(s) for distributing requests across models, retries, caching, **and progress display style**. Set `progress="rich"` (default), `"tqdm"`, or `"manual"` to choose how progress is reported. The manual option prints an update every 30 seconds.
 3. **Arguments to process_prompts.** Per-call, you can set verbosity, whether to display progress, and whether to return just completions (rather than the full APIResponse object). This is also where you provide tools.
 
 Putting it all together:
@@ -80,6 +80,19 @@ await client.process_prompts_async(
     show_progress=False,
     return_completions_only=True
 )
+```
+
+### Queueing individual prompts
+
+You can queue prompts one at a time and track progress explicitly:
+
+```python
+client = LLMClient.basic("gpt-4.1-mini", progress="tqdm")
+client.open()
+task_id = client.start_nowait("hello there")
+# ... queue more tasks ...
+results = await client.wait_for_all()
+client.close()
 ```
 
 ## Multi-Turn Conversations

--- a/tests/one_off/test_rich_display.py
+++ b/tests/one_off/test_rich_display.py
@@ -2,8 +2,15 @@
 """Test the Rich display functionality."""
 
 import asyncio
+import importlib.util
+import pathlib
 
-from lm_deluge.tracker import StatusTracker
+spec = importlib.util.spec_from_file_location(
+    "status_tracker", pathlib.Path(__file__).resolve().parents[2] / "src" / "lm_deluge" / "tracker.py"
+)
+tracker_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tracker_module)  # type: ignore
+StatusTracker = tracker_module.StatusTracker
 
 
 async def test_rich_display():
@@ -14,7 +21,7 @@ async def test_rich_display():
         max_concurrent_requests=100,
         use_progress_bar=True,
         progress_bar_total=10,
-        use_rich=True,
+        progress_style="rich",
     )
 
     # Initialize Rich display
@@ -64,7 +71,7 @@ def test_rich_disabled():
         max_concurrent_requests=100,
         use_progress_bar=True,
         progress_bar_total=5,
-        use_rich=False,  # Explicitly disable Rich
+        progress_style="tqdm",  # Explicitly use tqdm
     )
 
     tracker.init_progress_bar()
@@ -88,7 +95,7 @@ def test_progress_disabled():
         max_tokens_per_minute=10000,
         max_concurrent_requests=100,
         use_progress_bar=False,  # Progress disabled
-        use_rich=False,  # Should be ignored
+        progress_style="tqdm",  # Should be ignored
     )
 
     tracker.init_progress_bar()


### PR DESCRIPTION
## Summary
- allow choosing progress bar implementation (rich, tqdm, or manual printer)
- add open/close methods and dynamic totals for queued tasks
- document queueing usage and progress options

## Testing
- `pytest tests/one_off/test_rich_display.py::test_progress_disabled -q`
- `pytest tests/one_off/test_rich_display.py::test_rich_disabled -q`

------
https://chatgpt.com/codex/tasks/task_e_688e74e5d0d48322b76b51bcb0a0b258