### PR TITLE
Add as_completed async task iterator to LLMClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,17 @@ await client.process_prompts_async(
 
 ### Queueing individual prompts
 
-You can queue prompts one at a time and track progress explicitly:
+You can queue prompts one at a time and track progress explicitly. Iterate over
+results as they finish with `as_completed` (or gather them all at once with
+`wait_for_all`):
 
 ```python
 client = LLMClient("gpt-4.1-mini", progress="tqdm")
 client.open()
-task_id = client.start_nowait("hello there")
+client.start_nowait("hello there")
 # ... queue more tasks ...
-results = await client.wait_for_all()
+async for task_id, result in client.as_completed():
+    print(task_id, result.completion)
 client.close()
 ```
 


### PR DESCRIPTION
## Summary
- add `as_completed` async generator to `LLMClient` to yield task results as they finish
- document queueing workflow with `as_completed`
- add regression test for `as_completed`

## Testing
- `python -m black src/lm_deluge/client.py tests/core/test_async_tasks.py`
- `pytest tests/core/test_async_tasks.py` *(fails: ProxyError: Unable to connect to proxy)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f9d67a36083228f0e22813647240c