### PR TITLE
Ensure Message.to_log only returns JSON-serialisable data

### DIFF
--- a/tests/core/test_message_serialization.py
+++ b/tests/core/test_message_serialization.py
@@ -1,0 +1,20 @@
+import json
+
+from lm_deluge.prompt import Message, ToolCall, ToolResult
+
+
+def test_message_to_log_handles_unserialisable_arguments():
+    tc = ToolCall(id="1", name="fn", arguments={"callable": len})
+    msg = Message("assistant", [tc])
+    data = msg.to_log()
+    json.dumps(data)  # should not raise
+    assert data["content"][0]["arguments"]["callable"] == repr(len)
+
+
+def test_message_to_log_handles_unserialisable_results():
+    tr = ToolResult(tool_call_id="1", result={"fn": max})
+    msg = Message("assistant", [tr])
+    data = msg.to_log()
+    json.dumps(data)  # should not raise
+    assert data["content"][0]["result"]["fn"] == repr(max)
+


### PR DESCRIPTION
## Summary
- Sanitize `Message.to_log` output so tool call arguments and results always serialise
- Add tests covering non-serialisable arguments and results

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a4233aa88322b4cd192f2d294280